### PR TITLE
Fixes GetItemByName by passing src to originalFunc

### DIFF
--- a/server/inventory/qs.lua
+++ b/server/inventory/qs.lua
@@ -35,11 +35,11 @@ overrideFunction.methods = retreiveExportsData(qs_inventory, {
     getItem = {
         originalMethod = 'GetItemByName',
         modifier = {
-            passSource = true,
-            effect = function(originalFun, itemName)
-                local data = originalFun(itemName)
+            passSource = true, -- Src doesn't actually seem to be passed to originalFunc
+            effect = function(originalFunc, src, itemName)
+                local data = originalFunc(src, itemName)
                 if not data then
-                    return false, 'Item not exist or you don\'t have it'
+                    return false, 'Item does not exist or you don\'t have it'
                 end
                 return {
                     label = data.label,


### PR DESCRIPTION
A customer of mine reported a bug with my script and their qs-inventory setup. 

It seems the `qs.lua` no longer passes the `src` to `GetItemByName` and the arguments within effect were not updated so it was trying to pass the `src` instead of the item name into the originalFunc. This is now tested and working again.